### PR TITLE
Parse query parameters using the swagger spec field properties

### DIFF
--- a/swag-validator.go
+++ b/swag-validator.go
@@ -1,4 +1,4 @@
-package swag_validator
+package swagvalidator
 
 import (
 	"bytes"
@@ -16,6 +16,7 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
+// MaxMemory ...
 const MaxMemory = 1 * 1024 * 1024
 
 // RequestSchema ...


### PR DESCRIPTION
This allows for correctly validating query parameters based on their type in the swagger schema definition