### PR TITLE
Support json.RawMessage

### DIFF
--- a/swag-validator.go
+++ b/swag-validator.go
@@ -293,7 +293,7 @@ func buildSchemaDefinitions(api *swagger.API) map[string]SchemaDefinition {
 			}
 
 			// for json.RawMessage
-			if p.GoType.Kind() == reflect.Uint8 && p.Type == "array" {
+			if p.GoType.PkgPath() == "encoding/json" && p.GoType.Name() == "RawMessage" {
 				sp.Type = []string{"raw_message"}
 			}
 

--- a/swag-validator.go
+++ b/swag-validator.go
@@ -291,6 +291,12 @@ func buildSchemaDefinitions(api *swagger.API) map[string]SchemaDefinition {
 			if p.Nullable {
 				sp.Type = append(sp.Type, "null")
 			}
+
+			// for json.RawMessage
+			if p.GoType.Kind() == reflect.Uint8 && p.Type == "array" {
+				sp.Type = []string{"raw_message"}
+			}
+
 			schemaDef.Properties[k] = sp
 		}
 		defs[d.Name] = schemaDef

--- a/swag-validator.go
+++ b/swag-validator.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/kazyshr/gojsonschema"
 	"github.com/miketonks/swag/swagger"
-	"github.com/xeipuuv/gojsonschema"
 )
 
 // MaxMemory ...


### PR DESCRIPTION
Currently json.RawMessage is parsed to "array" type. So I created new type "raw_message". Then gojsonschema will handle it properly.