### PR TITLE
Throw a 500 Internal Server Error if an invalid Swagger spec is encountered

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/miketonks/swag-validator
+
+go 1.12

--- a/swag-validator.go
+++ b/swag-validator.go
@@ -240,8 +240,10 @@ func SwaggerValidator(api *swagger.API) gin.HandlerFunc {
 		result, err := gojsonschema.Validate(schemaLoader, documentLoader)
 
 		if err != nil {
-			// fmt.Printf("ERROR: %s", err)
-			c.Next()
+			// fmt.Printf("ERROR: %s\n", err)
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+				"message": "swagger document " + err.Error(),
+			})
 
 		} else if result.Valid() {
 			// fmt.Printf("The document is valid\n")


### PR DESCRIPTION
Also adds a `go.mod`.